### PR TITLE
restore exercises filter on matrix (& set min width for table divisions)

### DIFF
--- a/src/components/GradesStudentsMatrix.vue
+++ b/src/components/GradesStudentsMatrix.vue
@@ -26,7 +26,7 @@ const showDetails = (studentId, exerciseId) => {
         <tr>
           <th scope="col">Student</th>
           <th scope="col" v-for="ex in filteredExercisesList()" :key="ex">
-            {{ ex.path }}
+            <i @click="applyExercisesListFilter(ex.id)" style="cursor: pointer">{{ ex.path }}</i>
           </th>
         </tr>
       </thead>
@@ -43,11 +43,13 @@ const showDetails = (studentId, exerciseId) => {
             <add-grade-form :studentId="st.id" :exerciseId="ex.id" v-if="showGrader"/> 
           </td>
         </tr>
-
-
       </tbody>
-
     </table>
-
   </div>
 </template>
+
+<style>
+  td {
+    min-width: 200px;
+  }
+</style>

--- a/src/components/student/StudentsList.vue
+++ b/src/components/student/StudentsList.vue
@@ -14,6 +14,29 @@ function handleRemove(studentId) {
 </script>
 
 <template>
+  <div class="overflow-auto">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Student</th>
+          <th scope="col">Repository</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="st in students" :key="st">
+          <th scope="row">
+            <b>{{ st.lastName + " " + st.firstName }}</b>
+          </th>
+          <td>
+            <a v-bind:href="'https://github.com/' + st.githubUsername + '/plataformas-moviles-entregas/'">
+              {{ st.githubUsername }}
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
   <ul class="studentsList">
     <li v-for="st in students" :key="st">
       <pre>{{ st }}</pre>


### PR DESCRIPTION
On the previous commit I've accidentaly removed the exercises filter. Now it should be restored

Another thing to revise is that now <td> tags have a minimum width of 200px in order for the content not to "break" on smaller devices