### PR TITLE
feat: add courses

### DIFF
--- a/src/components/MainNavbar.vue
+++ b/src/components/MainNavbar.vue
@@ -9,6 +9,9 @@ import { RouterLink } from 'vue-router'
         <RouterLink to="/">Home</RouterLink>
       </li>
       <li>
+        <RouterLink to="/courses">Courses</RouterLink>
+      </li>
+      <li>
         <RouterLink to="/students">Students</RouterLink>
       </li>
       <li>

--- a/src/components/courses/AddCourseForm.vue
+++ b/src/components/courses/AddCourseForm.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { ref } from 'vue'
+import { useCoursesStore } from '@/stores/courses';
+
+const EMPTY_COURSE = {
+  title: '',
+  school_year: ''
+}
+
+const { addCourse } = useCoursesStore()
+
+const course = ref({ ...EMPTY_COURSE })
+
+function onSubmit() {
+  addCourse({
+    ...course.value
+  })
+  course.value = { ...EMPTY_COURSE }
+}
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <div class="grid">
+      <div>
+        <label for="title">Title</label>
+        <input type="text" id="title" v-model="course.title" />
+      </div>
+
+      <div>
+        <label for="school_year">School year</label>
+        <input type="text" id="school_year" v-model="course.school_year" :placeholder="new Date().getFullYear()" />
+      </div>
+    </div>
+
+    <button type="submit">Add Course</button>
+  </form>
+</template>

--- a/src/components/courses/CoursesList.vue
+++ b/src/components/courses/CoursesList.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { storeToRefs } from 'pinia'
+import { useCoursesStore } from '@/stores/courses';
+
+const coursesStore = useCoursesStore()
+const { list: courses } = storeToRefs(coursesStore)
+
+function handleRemove(courseId) {
+  coursesStore.removeCourse(courseId)
+}
+</script>
+
+<template>
+  <ul class="coursesList">
+    <li v-for="course in courses" :key="course">
+      <pre>{{ course }}</pre>
+      <button @click="handleRemove(course.id)">x</button>
+    </li>
+  </ul>
+</template>
+
+<style lang="scss">
+ul.coursesList {
+  li {
+    list-style: none;
+    list-style-position: outside;
+    margin-bottom: 1rem;
+    display: flex;
+  }
+
+  pre {
+    margin: 0;
+    flex-grow: 1;
+  }
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import HomeView from '../views/HomeView.vue'
 import StudentsView from '../views/StudentsView.vue'
 import ExercisesView from '../views/ExercisesView.vue'
 import GradesView from '../views/GradesView.vue'
+import CoursesView from '@/views/CoursesView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -12,6 +13,11 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView
+    },
+    {
+      path: '/courses',
+      name: 'courses',
+      component: CoursesView
     },
     {
       path: '/students',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,7 +4,7 @@ import HomeView from '../views/HomeView.vue'
 import StudentsView from '../views/StudentsView.vue'
 import ExercisesView from '../views/ExercisesView.vue'
 import GradesView from '../views/GradesView.vue'
-import CoursesView from '@/views/CoursesView.vue'
+import CoursesView from '../views/CoursesView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/stores/courses.js
+++ b/src/stores/courses.js
@@ -1,0 +1,31 @@
+import { ref } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { v4 as uuid } from 'uuid'
+import { createMockCourse } from '@/utils/functions'
+
+const getInitialValues = () => {
+  const defaultValues = [
+    createMockCourse('7mo2da'),
+    createMockCourse('7mo3ra'),
+    createMockCourse('7mo4ta')
+  ]
+  return useStorage('courses', defaultValues)
+}
+
+export const useCoursesStore = defineStore('courses', () => {
+  const list = ref(getInitialValues())
+
+  function addCourse(course) {
+    list.value.push({
+      id: uuid(),
+      ...course
+    })
+  }
+
+  function removeCourse(courseId) {
+    list.value = list.value.filter((st) => st.id !== courseId)
+  }
+
+  return { list, addCourse, removeCourse }
+})

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -26,3 +26,12 @@ export const createMockExercise = (exerciseId) => {
     path: `tp-${title}`
   }
 }
+
+export const createMockCourse = (courseId) => {
+  const title = courseId.toString() || randomString()
+  return {
+    id: uuid(),
+    title: title,
+    school_year: new Date().getFullYear()
+  }
+}

--- a/src/views/CoursesView.vue
+++ b/src/views/CoursesView.vue
@@ -1,0 +1,18 @@
+<script setup>
+import AddCourseForm from '@/components/courses/AddCourseForm.vue';
+import CoursesList from '@/components/courses/CoursesList.vue';
+</script>
+
+<template>
+  <div>
+    <h1>Courses</h1>
+
+    <details>
+      <summary role="button" class="secondary">Add</summary>
+      <add-course-form />
+    </details>
+
+    <h2>List All</h2>
+    <courses-list />
+  </div>
+</template>


### PR DESCRIPTION
This change involves a lot of new pieces of code regarding to the 'courses' logic

New files have been added/modified
- `src/components/MainNavbar.vue` now has a new link to go to the courses section
- `src/router/index.js` now has a new route that refers to the courses section
- `src/stores/courses.js`, which allows to store and remove courses
- `src/components/courses/AddCourseForm.vue`, which consists of a form to add new students to store
- `src/components/courses/CoursesList.vue`, which lists all courses in store